### PR TITLE
Dodgy link to the metadata in this example

### DIFF
--- a/src/RedisStackOverflow/RedisStackOverflow/default.htm
+++ b/src/RedisStackOverflow/RedisStackOverflow/default.htm
@@ -438,7 +438,7 @@
                     <a href="http://www.servicestack.net">ServiceStack</a>
                 </dd>
                 <dd>
-                    <a href="servicestack/metadata">Checkout the complete Web Services API</a>
+                    <a href="/metadata">Checkout the complete Web Services API</a>
                 </dd>
                 <dd>
                     <a href="http://www.servicestack.net">Uses</a>


### PR DESCRIPTION
in live links to http://servicestack.net/RedisStackOverflow/servicestack/metadata)
