### PR TITLE
moved links from servicestack.net to mono.servicestack.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,32 +19,32 @@ or clone this repo to download the source:
 
 A live demo and tutorials are available at the following locations:
 
-### [Backbone.js TODO app with REST and Redis backend](http://servicestack.net/Backbone.Todos/)
-[![Backbone REST and Redis TODOs](http://servicestack.net/showcase/img/todos-400x350.png)](http://servicestack.net/Backbone.Todos/)
+### [Backbone.js TODO app with REST and Redis backend](http://mono.servicestack.net/Backbone.Todos/)
+[![Backbone REST and Redis TODOs](http://mono.servicestack.net/showcase/img/todos-400x350.png)](http://mono.servicestack.net/Backbone.Todos/)
 
-### [Creating a Hello World Web service from scratch](http://servicestack.net/ServiceStack.Hello/)
-[![ServiceStacks Hello, World!](http://servicestack.net/showcase/img/hello-400x350.png)](http://servicestack.net/ServiceStack.Hello/)
+### [Creating a Hello World Web service from scratch](http://mono.servicestack.net/ServiceStack.Hello/)
+[![ServiceStacks Hello, World!](http://mono.servicestack.net/showcase/img/hello-400x350.png)](http://mono.servicestack.net/ServiceStack.Hello/)
 
-### [GitHub-like browser to manage remote filesystem over REST](http://servicestack.net/RestFiles/)
-[![GitHub-like REST Files](http://servicestack.net/showcase/img/restfiles-400x350.png)](http://servicestack.net/RestFiles/)
+### [GitHub-like browser to manage remote filesystem over REST](http://mono.servicestack.net/RestFiles/)
+[![GitHub-like REST Files](http://mono.servicestack.net/showcase/img/restfiles-400x350.png)](http://mono.servicestack.net/RestFiles/)
 
-### [Creating a StackOverflow-like app in Redis](http://servicestack.net/RedisStackOverflow/)
-[![Redis StackOverflow](http://servicestack.net/showcase/img/redisstackoverflow-400x350.png)](http://servicestack.net/RedisStackOverflow/)
+### [Creating a StackOverflow-like app in Redis](http://mono.servicestack.net/RedisStackOverflow/)
+[![Redis StackOverflow](http://mono.servicestack.net/showcase/img/redisstackoverflow-400x350.png)](http://mono.servicestack.net/RedisStackOverflow/)
 
-### [Northwind dataset services](http://servicestack.net/ServiceStack.Northwind/)
-[![Redis StackOverflow](http://servicestack.net/showcase/img/northwind-400x350.png)](http://servicestack.net/ServiceStack.Northwind/)
+### [Northwind dataset services](http://mono.servicestack.net/ServiceStack.Northwind/)
+[![Redis StackOverflow](http://mono.servicestack.net/showcase/img/northwind-400x350.png)](http://mono.servicestack.net/ServiceStack.Northwind/)
 
-### [Complete REST Web service example](http://servicestack.net/ServiceStack.MovieRest/)
-[![REST at the Movies!](http://servicestack.net/showcase/img/movierest-400x350.png)](http://servicestack.net/ServiceStack.MovieRest/)
+### [Complete REST Web service example](http://mono.servicestack.net/ServiceStack.MovieRest/)
+[![REST at the Movies!](http://mono.servicestack.net/showcase/img/movierest-400x350.png)](http://mono.servicestack.net/ServiceStack.MovieRest/)
 
-### [Calling Web Services with Ajax](http://servicestack.net/ServiceStack.Examples.Clients/)
-[![Ajax Example](http://servicestack.net/showcase/img/ajaxexample-400x350.png)](http://servicestack.net/ServiceStack.Examples.Clients/)
+### [Calling Web Services with Ajax](http://mono.servicestack.net/ServiceStack.Examples.Clients/)
+[![Ajax Example](http://mono.servicestack.net/showcase/img/ajaxexample-400x350.png)](http://mono.servicestack.net/ServiceStack.Examples.Clients/)
 
 ### Other examples
 * [Calling Web Services with Mono Touch](http://www.servicestack.net/monotouch/remote-info/)
-* [Calling Web Services using Silverlight](http://servicestack.net/ServiceStack.Examples.Clients/Silverlight.htm)
-* [Calling SOAP 1.1 Web Service Examples](http://servicestack.net/ServiceStack.Examples.Clients/Soap11.aspx)
-* [Calling SOAP 1.2 Web Service Examples](http://servicestack.net/ServiceStack.Examples.Clients/Soap12.aspx)
+* [Calling Web Services using Silverlight](http://mono.servicestack.net/ServiceStack.Examples.Clients/Silverlight.htm)
+* [Calling SOAP 1.1 Web Service Examples](http://mono.servicestack.net/ServiceStack.Examples.Clients/Soap11.aspx)
+* [Calling SOAP 1.2 Web Service Examples](http://mono.servicestack.net/ServiceStack.Examples.Clients/Soap12.aspx)
 
 _All live examples hosted on CentOS/Nginx/FastCGI/Mono_
 

--- a/src/Backbone.Todos/default.htm
+++ b/src/Backbone.Todos/default.htm
@@ -12,7 +12,7 @@
 <body>
     <a href="http://www.servicestack.net" style="display: block; position: absolute;
         top: 5px; left: 10px;">
-        <img src="http://servicestack.net/icon-home-eee.jpg" alt="ServiceStack Home" />
+        <img src="http://mono.servicestack.net/icon-home-eee.jpg" alt="ServiceStack Home" />
     </a>
     <!-- Todo App Interface -->
     <div id="todoapp">
@@ -47,7 +47,7 @@
         <br />
         Powered By Open Source
         <br />
-        <a href="http://servicestack.net">servicestack.net</a> | <a href="http://redis.io">redis</a>
+        <a href="http://mono.servicestack.net">servicestack.net</a> | <a href="http://redis.io">redis</a>
         | <a href="http://www.mono-project.com">mono</a>
     </div>
     <!-- Templates -->

--- a/src/ConsoleUtil/Program.cs
+++ b/src/ConsoleUtil/Program.cs
@@ -18,7 +18,7 @@ namespace ConsoleUtil
 				var json = File.ReadAllText(filePath);
 				Pages = JsonSerializer.DeserializeFromString<List<Page>>(json);
 
-				var webHostUrl = "http://servicestack.net/docs/";
+				var webHostUrl = "http://mono.servicestack.net/docs/";
 				foreach (var page in Pages)
 				{
 					//ReplaceOldLinks(webHostUrl, page);
@@ -53,7 +53,7 @@ namespace ConsoleUtil
 
 			content = content.Replace(
 				"(https://github.com/ServiceStack/ServiceStack.Redis/wiki/Caching)",
-				"(http://servicestack.net/docs/framework/caching-options)");
+				"(http://mono.servicestack.net/docs/framework/caching-options)");
 
 			Save(srcPage, content);
 		}

--- a/src/Docs/examples/servicestack-examples.md
+++ b/src/Docs/examples/servicestack-examples.md
@@ -8,29 +8,29 @@ for twitter updates.
 
 A live demo and tutorials are available at the following locations:
 
-### [Backbone.js TODO app with REST and Redis backend](http://servicestack.net/Backbone.Todos/)
-[![Backbone REST and Redis TODOs](http://servicestack.net/showcase/img/todos-400x350.png)](http://servicestack.net/Backbone.Todos/)
+### [Backbone.js TODO app with REST and Redis backend](http://mono.servicestack.net/Backbone.Todos/)
+[![Backbone REST and Redis TODOs](http://mono.servicestack.net/showcase/img/todos-400x350.png)](http://mono.servicestack.net/Backbone.Todos/)
 
-### [Creating a Hello World Web service from scratch](http://servicestack.net/ServiceStack.Hello/)
-[![ServiceStacks Hello, World!](http://servicestack.net/showcase/img/hello-400x350.png)](http://servicestack.net/ServiceStack.Hello/)
+### [Creating a Hello World Web service from scratch](http://mono.servicestack.net/ServiceStack.Hello/)
+[![ServiceStacks Hello, World!](http://mono.servicestack.net/showcase/img/hello-400x350.png)](http://mono.servicestack.net/ServiceStack.Hello/)
 
-### [GitHub-like browser to manage remote filesystem over REST](http://servicestack.net/RestFiles/)
-[![GitHub-like REST Files](http://servicestack.net/showcase/img/restfiles-400x350.png)](http://servicestack.net/RestFiles/)
+### [GitHub-like browser to manage remote filesystem over REST](http://mono.servicestack.net/RestFiles/)
+[![GitHub-like REST Files](http://mono.servicestack.net/showcase/img/restfiles-400x350.png)](http://mono.servicestack.net/RestFiles/)
 
-### [Creating a StackOverflow-like app in Redis](http://servicestack.net/RedisStackOverflow/)
-[![Redis StackOverflow](http://servicestack.net/showcase/img/redisstackoverflow-400x350.png)](http://servicestack.net/RedisStackOverflow/)
+### [Creating a StackOverflow-like app in Redis](http://mono.servicestack.net/RedisStackOverflow/)
+[![Redis StackOverflow](http://mono.servicestack.net/showcase/img/redisstackoverflow-400x350.png)](http://mono.servicestack.net/RedisStackOverflow/)
 
-### [Complete REST Web service example](http://servicestack.net/ServiceStack.MovieRest/)
-[![REST at the Movies!](http://servicestack.net/showcase/img/movierest-400x350.png)](http://servicestack.net/ServiceStack.MovieRest/)
+### [Complete REST Web service example](http://mono.servicestack.net/ServiceStack.MovieRest/)
+[![REST at the Movies!](http://mono.servicestack.net/showcase/img/movierest-400x350.png)](http://mono.servicestack.net/ServiceStack.MovieRest/)
 
-### [Calling Web Services with Ajax](http://servicestack.net/ServiceStack.Examples.Clients/)
-[![Ajax Example](http://servicestack.net/showcase/img/ajaxexample-400x350.png)](http://servicestack.net/ServiceStack.Examples.Clients/)
+### [Calling Web Services with Ajax](http://mono.servicestack.net/ServiceStack.Examples.Clients/)
+[![Ajax Example](http://mono.servicestack.net/showcase/img/ajaxexample-400x350.png)](http://mono.servicestack.net/ServiceStack.Examples.Clients/)
 
 ### Other examples
 * [Calling Web Services with Mono Touch](http://www.servicestack.net/monotouch/remote-info/)
-* [Calling Web Services using Silverlight](http://servicestack.net/ServiceStack.Examples.Clients/Silverlight.htm)
-* [Calling SOAP 1.1 Web Service Examples](http://servicestack.net/ServiceStack.Examples.Clients/Soap11.aspx)
-* [Calling SOAP 1.2 Web Service Examples](http://servicestack.net/ServiceStack.Examples.Clients/Soap12.aspx)
+* [Calling Web Services using Silverlight](http://mono.servicestack.net/ServiceStack.Examples.Clients/Silverlight.htm)
+* [Calling SOAP 1.1 Web Service Examples](http://mono.servicestack.net/ServiceStack.Examples.Clients/Soap11.aspx)
+* [Calling SOAP 1.2 Web Service Examples](http://mono.servicestack.net/ServiceStack.Examples.Clients/Soap12.aspx)
 
 _All live examples hosted on CentOS/Nginx/FastCGI/Mono_
 

--- a/src/Docs/framework/caching-options.md
+++ b/src/Docs/framework/caching-options.md
@@ -8,11 +8,11 @@ for the following cache providers:
 
 # Live Example and code
 
-A live demo of the ICacheClient is available in [The ServiceStack.Northwind's example project](http://servicestack.net/ServiceStack.Northwind/). Here are some requests to cached services:
+A live demo of the ICacheClient is available in [The ServiceStack.Northwind's example project](http://mono.servicestack.net/ServiceStack.Northwind/). Here are some requests to cached services:
 
-  * [/customers](http://servicestack.net/ServiceStack.Northwind/cached/customers)
-  * [/customers/ALFKI](http://servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI)
-  * [/customers/ALFKI/orders](http://servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI/orders)
+  * [/customers](http://mono.servicestack.net/ServiceStack.Northwind/cached/customers)
+  * [/customers/ALFKI](http://mono.servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI)
+  * [/customers/ALFKI/orders](http://mono.servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI/orders)
 
 Which are simply existing web services wrapped using **ICacheClient** that are contained in [CachedServices.cs](https://github.com/ServiceStack/ServiceStack.Examples/blob/master/src/ServiceStack.Northwind/ServiceStack.Northwind.ServiceInterface/CachedServices.cs)
 

--- a/src/Docs/framework/csv-format.md
+++ b/src/Docs/framework/csv-format.md
@@ -58,7 +58,7 @@ This is how the above web service output looks when opened up in [google docs](h
 
 Alternative in following with the HTTP specification you can also specify content-type `"text/csv"` in the *Accept* header of your HttpClient, e.g:
 
-    var httpReq = (HttpWebRequest)WebRequest.Create("http://servicestack.net/ServiceStack.MovieRest/movies");
+    var httpReq = (HttpWebRequest)WebRequest.Create("http://mono.servicestack.net/ServiceStack.MovieRest/movies");
     httpReq.Accept = "text/csv";
     var csv = new StreamReader(httpReq.GetResponse().GetResponseStream()).ReadToEnd();
 

--- a/src/Docs/framework/json-report-format.md
+++ b/src/Docs/framework/json-report-format.md
@@ -4,16 +4,16 @@
 
 These examples are simply links to existing ServiceStack web services, which based on your browsers user-agent (i.e. Accept: 'text/html') provides this HTML format instead of the other serialization formats. 
 
-  - **Northwind Database: **  [All Customers](http://servicestack.net/ServiceStack.Northwind/customers), [Customer Detail](http://servicestack.net/ServiceStack.Northwind/customers/ALFKI), [Customer Orders](http://servicestack.net/ServiceStack.Northwind/orders)
-  - **RedisStackOverflow: **  [Latest Questions](http://servicestack.net/RedisStackOverflow/questions) and [Site Stats](http://servicestack.net/RedisStackOverflow/stats)
-  - **RestMovies: **  [All Movie listings](http://servicestack.net/ServiceStack.MovieRest/movies)
-  - **RestFiles: **  [Root Directory](http://servicestack.net/RestFiles/files)
+  - **Northwind Database: **  [All Customers](http://mono.servicestack.net/ServiceStack.Northwind/customers), [Customer Detail](http://mono.servicestack.net/ServiceStack.Northwind/customers/ALFKI), [Customer Orders](http://mono.servicestack.net/ServiceStack.Northwind/orders)
+  - **RedisStackOverflow: **  [Latest Questions](http://mono.servicestack.net/RedisStackOverflow/questions) and [Site Stats](http://mono.servicestack.net/RedisStackOverflow/stats)
+  - **RestMovies: **  [All Movie listings](http://mono.servicestack.net/ServiceStack.MovieRest/movies)
+  - **RestFiles: **  [Root Directory](http://mono.servicestack.net/RestFiles/files)
 
-[![HTML5 Report Format](http://servicestack.net/img/HTML5Format.png)](http://servicestack.net/ServiceStack.Northwind/customers/ALFKI)
+[![HTML5 Report Format](http://mono.servicestack.net/img/HTML5Format.png)](http://mono.servicestack.net/ServiceStack.Northwind/customers/ALFKI)
 
 To see it in action, **view the source** in your browser. Webkit and Firefox users can simply go to the url below:
 
-    view-source:http://servicestack.net/ServiceStack.Northwind/customers/ALFKI
+    view-source:http://mono.servicestack.net/ServiceStack.Northwind/customers/ALFKI
 
 Note: To view the web services in a different format simply append **?format=[json|xml|html|csv|jsv]** to the query string.
 

--- a/src/Docs/framework/nuget.md
+++ b/src/Docs/framework/nuget.md
@@ -4,15 +4,15 @@ To make it easier for developers to get started we're now maintaining NuGet pack
 
 So if you have [NuGet](http://nuget.org) installed, the easiest way to get started is to create a new ASP.NET Web Application and install the **ServiceStack** package:
 
-![Install-Package ServiceStack](http://servicestack.net/img/nuget-servicestack.png)
+![Install-Package ServiceStack](http://mono.servicestack.net/img/nuget-servicestack.png)
 
 This automates the following manual steps: 
 
 * Add the ServiceStack dlls to your standard VS.NET ASP.NET Web Application 
 * Register the ServiceStack handler in your Web.Config
 * Configure your AppHost 
-* Create a **[Hello](http://servicestack.net/ServiceStack.Hello/)** web service
-* Create a **[TODO](http://servicestack.net/Backbone.Todos/)** RESTful web service
+* Create a **[Hello](http://mono.servicestack.net/ServiceStack.Hello/)** web service
+* Create a **[TODO](http://mono.servicestack.net/Backbone.Todos/)** RESTful web service
 
 Although we believe this to be a popular starting point, it is not the only one as we have examples of Windows Services, Stand-alone Console Hosts, Hosting together with an existing web framework at a Custom Path - Templates available in the **/StarterTemplates** folder in the [ServiceStack.Examples project](https://github.com/ServiceStack/ServiceStack.Examples/downloads).
 
@@ -27,11 +27,11 @@ Downloadable separately from ServiceStack itself is it's string powers. Inside [
 * StringExtensions - Xml/Json/Csv/Url encoding, BaseConvert, Rot13, Hex escape, etc.
 * Stream, Reflection, List, DateTime, etc extensions and utils
 
-![Install-Package ServiceStack.Text](http://servicestack.net/img/nuget-servicestack.text.png)
+![Install-Package ServiceStack.Text](http://mono.servicestack.net/img/nuget-servicestack.text.png)
 
 ## NuGet ServiceStack.Redis
 
-With a hope to introduce more .NET developers to the high-performance and productive NoSQL worlds, we also include a full-featured [C# Redis client](~/redis-client/redis-client) allowing you to build [complete apps with it](http://servicestack.net/RedisStackOverflow/). [Redis](http://redis.io/) is the fastest NoSQL database in the world that is capable of achieving [about 110000 SETs and 81000 GETs per second](http://redis.io/topics/benchmarks).
+With a hope to introduce more .NET developers to the high-performance and productive NoSQL worlds, we also include a full-featured [C# Redis client](~/redis-client/redis-client) allowing you to build [complete apps with it](http://mono.servicestack.net/RedisStackOverflow/). [Redis](http://redis.io/) is the fastest NoSQL database in the world that is capable of achieving [about 110000 SETs and 81000 GETs per second](http://redis.io/topics/benchmarks).
 
 The C# Redis Client features:
 
@@ -46,7 +46,7 @@ For .NET developers new to Redis, we invite you to check out the following tutor
 * [Designing a NoSQL Database using Redis](~/redis-client/designing-nosql-database)
 * [Painless data migrations with schema-less NoSQL datastores](~/redis-client/schemaless-nosql-migrations)
 
-![Install-Package ServiceStack.Redis](http://servicestack.net/img/nuget-servicestack.redis.png)
+![Install-Package ServiceStack.Redis](http://mono.servicestack.net/img/nuget-servicestack.redis.png)
 
 ## NuGet ServiceStack.OrmLite
 
@@ -56,12 +56,12 @@ It's primary feature over other ORMs is its auto-support for blobs where any com
 
 Currently OrmLite comes in SQLite and SQL Server RDBMS's flavors and each are downloadable separately via NuGet:
 
-![Install-Package ServiceStack.OrmLite.SqlServer](http://servicestack.net/img/nuget-servicestack.ormlite.sqlserver.png)
+![Install-Package ServiceStack.OrmLite.SqlServer](http://mono.servicestack.net/img/nuget-servicestack.ormlite.sqlserver.png)
 
 For Sqlite 32 and 64bit embedded .NET libraries are available:
 
-![Install-Package ServiceStack.OrmLite.Sqlite32](http://servicestack.net/img/nuget-servicestack.ormlite.sqlite32.png)
+![Install-Package ServiceStack.OrmLite.Sqlite32](http://mono.servicestack.net/img/nuget-servicestack.ormlite.sqlite32.png)
 
-![Install-Package ServiceStack.OrmLite.Sqlite64](http://servicestack.net/img/nuget-servicestack.ormlite.sqlite64.png)
+![Install-Package ServiceStack.OrmLite.Sqlite64](http://mono.servicestack.net/img/nuget-servicestack.ormlite.sqlite64.png)
 
 

--- a/src/Docs/framework/overview.md
+++ b/src/Docs/framework/overview.md
@@ -140,14 +140,14 @@ Online tutorials that walks you through developing and calling web services is a
 Unlike other web services frameworks ServiceStack let's you develop web services using strongly-typed models and DTO's.
 This lets ServiceStack and other tools to have a greater intelligence about your services allowing:
 
-- [Multiple serialization formats (JSON, XML, JSV and SOAP with extensible plugin model for more)](http://servicestack.net/ServiceStack.Hello/servicestack/metadata)
+- [Multiple serialization formats (JSON, XML, JSV and SOAP with extensible plugin model for more)](http://mono.servicestack.net/ServiceStack.Hello/servicestack/metadata)
 - [A single re-usable C# Generic Client (In JSON, JSV, XML and SOAP flavors) that can talk to all your services.](https://github.com/ServiceStack/ServiceStack.Extras/blob/master/doc/UsageExamples/UsingServiceClients.cs)
 - [Re-use your Web Service DTOs (i.e. no code-gen) on your client applications so you're never out-of-sync](https://github.com/ServiceStack/ServiceStack.Extras/blob/master/doc/UsageExamples/UsingServiceClients.cs)
 - [Automatic serialization of Exceptions in your DTOs ResponseStatus](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.ServiceInterface/ServiceBase.cs#L154)
 - [The possibility of a base class for all your services to put high-level application logic (i.e security, logging, etc)](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.ServiceInterface/ServiceBase.cs#L24)
 - [Highly testable, your in-memory unit tests for your service can also be used as integration tests](https://github.com/ServiceStack/ServiceStack/blob/master/tests/ServiceStack.WebHost.IntegrationTests/Tests/WebServicesTests.cs)
 - [Built-in rolling web service error logging (if Redis is Configured in your AppHost)](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.ServiceInterface/ServiceBase.cs#L122)
-- [Rich REST and HTML support on all web services with x-www-form-urlencoded & multipart/form-data (i.e. FORM posts and file uploads)](http://servicestack.net/ServiceStack.Hello/)
+- [Rich REST and HTML support on all web services with x-www-form-urlencoded & multipart/form-data (i.e. FORM posts and file uploads)](http://mono.servicestack.net/ServiceStack.Hello/)
 
 ## Define web services following Martin Fowlers Data Transfer Object Pattern:
 

--- a/src/Docs/framework/release-notes.md
+++ b/src/Docs/framework/release-notes.md
@@ -279,9 +279,9 @@ An example MonoTouch project that uses these Sync and Async C# ServiceClients to
 
 As we have received a number of requests to provide NuGet packages for ServiceStack and its components, we're now happy to say we're now NuGet compliant! Where a configured and working ServiceStack web framework is just 1 NuGet command away :)
 
-[![Install-Package ServiceStack](http://servicestack.net/img/nuget-servicestack.png)](~/framework/nuget)
+[![Install-Package ServiceStack](http://mono.servicestack.net/img/nuget-servicestack.png)](~/framework/nuget)
 
-This will add the ServiceStack dlls to your standard VS.NET ASP.NET Web Application, Register ServiceStack handler in your Web.Config, configure your AppHost and create both a **[Hello](http://servicestack.net/ServiceStack.Hello/)** and a fully-operational **[TODO REST service](http://servicestack.net/Backbone.Todos/)**.
+This will add the ServiceStack dlls to your standard VS.NET ASP.NET Web Application, Register ServiceStack handler in your Web.Config, configure your AppHost and create both a **[Hello](http://mono.servicestack.net/ServiceStack.Hello/)** and a fully-operational **[TODO REST service](http://mono.servicestack.net/Backbone.Todos/)**.
 
 Together with just 2 static content files ([default.htm](https://github.com/ServiceStack/ServiceStack/blob/master/NuGet/ServiceStack/content/default.htm) and [jqunback-1.51.js](https://github.com/AjaxStack/AjaxStack)) you get a fully configured and working RESTful application (*which as an aside benefit we hope encourages .NET developers into the [beautiful world of Backbone.js](http://documentcloud.github.com/backbone/) and Single Page Ajax Applications*).
 
@@ -295,10 +295,10 @@ Although this normally shouldn't warrant a release line item, for the technology
 We believe the overview slides provide the best starting point for new developers looking to find out the benefits of ServiceStack and how they can easily develop REST services with it. Today, we're releasing the following 2 slides:
 
 ### [ServiceStack Overview and Features](https://docs.google.com/present/view?id=dg3mcfb_208gv3kcnd8)
-[![Install-Package ServiceStack](http://servicestack.net/img/slides-01-overview-300.png)](https://docs.google.com/present/view?id=dg3mcfb_208gv3kcnd8)
+[![Install-Package ServiceStack](http://mono.servicestack.net/img/slides-01-overview-300.png)](https://docs.google.com/present/view?id=dg3mcfb_208gv3kcnd8)
 
 ### [Creating REST Web Services](https://docs.google.com/present/view?id=dg3mcfb_213gsvvmmfk)
-[![Install-Package ServiceStack](http://servicestack.net/img/slides-02-create-rest-service-300.png)](https://docs.google.com/present/view?id=dg3mcfb_213gsvvmmfk)
+[![Install-Package ServiceStack](http://mono.servicestack.net/img/slides-02-create-rest-service-300.png)](https://docs.google.com/present/view?id=dg3mcfb_213gsvvmmfk)
 
 ## Better configuration
 
@@ -344,7 +344,7 @@ From the [author](http://twitter.com/jashkenas) of the popular and game-changing
 
 Our first action was porting Backbone's example TODO app and replace its HTML5 localStorage backend with a ServiceStack REST + Redis one. This was quite easy to do and we were happy that [resulting C# server code for the REST backend](https://github.com/ServiceStack/ServiceStack.Examples/blob/master/src/Backbone.Todos/Global.asax.cs) ended up weighing in at less than the size of VS.NET's default Web.config file :)
 
-Like the rest of our examples a **[live demo is available](http://servicestack.net/Backbone.Todos/)**.
+Like the rest of our examples a **[live demo is available](http://mono.servicestack.net/Backbone.Todos/)**.
 
 ### TODO app now in all Starter templates
 
@@ -466,25 +466,25 @@ I invite all ServiceStack users who want to share their generic high-level funct
 The biggest feature added in this release is likely the new HTML5 report format that generates a human-readable HTML view of your web services response when viewing it in a web browser.
 Good news is, like the [[ServiceStack-CSV-Format]] it works with your existing web services as-is, with no configuration or code-changes required.
   
-[![HTML5 Report Format](http://servicestack.net/img/HTML5Format.png)](~/framework/json-report-format)
+[![HTML5 Report Format](http://mono.servicestack.net/img/HTML5Format.png)](~/framework/json-report-format)
 
 Here are some results of web services created before the newer HTML5 and CSV formats existed:
 
-  * **RedisStackOverflow** [Latest Questions](http://servicestack.net/RedisStackOverflow/questions)
-  * **RestMovies** [All Movie listings](http://servicestack.net/ServiceStack.MovieRest/movies)
-  * **RestFiles** [Root Directory](http://servicestack.net/RestFiles/files)
+  * **RedisStackOverflow** [Latest Questions](http://mono.servicestack.net/RedisStackOverflow/questions)
+  * **RestMovies** [All Movie listings](http://mono.servicestack.net/ServiceStack.MovieRest/movies)
+  * **RestFiles** [Root Directory](http://mono.servicestack.net/RestFiles/files)
 
 Use the **?format=[json|xml|html|csv|jsv]** to toggle and view the same web service in different formats.
 
 ### New ServiceStack.Northwind Example project added
 
 In order to be able to better demonstrate features with a 'real-world' DataSet, a new ServiceStack.Northwind project has been added which inspects the Northwind dataset from an SQLite database.
-A live demo is hosted at [[http://servicestack.net/ServiceStack.Northwind/]]. Here are some links below to better demonstrate the new HTML format with a real-world dataset:
+A live demo is hosted at [[http://mono.servicestack.net/ServiceStack.Northwind/]]. Here are some links below to better demonstrate the new HTML format with a real-world dataset:
 
 #### Northwind Database REST web services
-  * [All Customers](http://servicestack.net/ServiceStack.Northwind/customers) 
-  * [Customer Detail](http://servicestack.net/ServiceStack.Northwind/customers/ALFKI)
-  * [Customer Orders](http://servicestack.net/ServiceStack.Northwind/customers/ALFKI/orders)
+  * [All Customers](http://mono.servicestack.net/ServiceStack.Northwind/customers) 
+  * [Customer Detail](http://mono.servicestack.net/ServiceStack.Northwind/customers/ALFKI)
+  * [Customer Orders](http://mono.servicestack.net/ServiceStack.Northwind/customers/ALFKI/orders)
 
 
 ### Improved Caching
@@ -510,9 +510,9 @@ The above code caches the most optimal output based on browser capabilities, i.e
 To see the difference caching provides, here are cached equivalents of the above REST web service calls:
 
 #### Northwind Database **Cached** REST web services
-  * [All Customers](http://servicestack.net/ServiceStack.Northwind/cached/customers) 
-  * [Customer Detail](http://servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI)
-  * [Customer Orders](http://servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI/orders)
+  * [All Customers](http://mono.servicestack.net/ServiceStack.Northwind/cached/customers) 
+  * [Customer Detail](http://mono.servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI)
+  * [Customer Orders](http://mono.servicestack.net/ServiceStack.Northwind/cached/customers/ALFKI/orders)
 
 
 ### API Changes
@@ -538,9 +538,9 @@ Also added is the ability to resolve existing web services (already auto-wired b
     * [Async C# client examples](https://github.com/ServiceStack/ServiceStack.Examples/blob/master/src/RestFiles/RestFiles.Tests/AsyncRestClientTests.cs)
 
 ## New RestFiles project added to [ServiceStack.Examples](https://github.com/ServiceStack/ServiceStack.Examples/) GitHub project:
-#### Live demo available at: [servicestack.net/RestFiles/](http://servicestack.net/RestFiles/)
+#### Live demo available at: [servicestack.net/RestFiles/](http://mono.servicestack.net/RestFiles/)
 
-  * Provides a complete remote file system management over a [RESTful api](http://servicestack.net/RestFiles/servicestack/metadata) 
+  * Provides a complete remote file system management over a [RESTful api](http://mono.servicestack.net/RestFiles/servicestack/metadata) 
   * The complete RESTful /files web service implementation is only [**1 C# page class**](https://github.com/ServiceStack/ServiceStack.Examples/blob/master/src/RestFiles/RestFiles.ServiceInterface/FilesService.cs)
   * Includes a pure Ajax client to provide a **GitHub-like** file browsing experience, written in only [**1 static HTML page, using only jQuery**](https://github.com/ServiceStack/ServiceStack.Examples/blob/master/src/RestFiles/RestFiles/default.htm)
    * [C# integration test examples](https://github.com/ServiceStack/ServiceStack.Examples/blob/master/src/RestFiles/RestFiles.Tests/) are also included showing how to access this RESTful api over sync and async C# clients

--- a/src/Docs/markdown/markdown-razor.md
+++ b/src/Docs/markdown/markdown-razor.md
@@ -16,7 +16,7 @@ You can define a base class for all your markdown pages by implementing **Markdo
 register it in your AppHost with:
 
     SetConfig(new EndpointHostConfig {
-        WebHostUrl = "http://servicestack.net/docs",   //Replace prefix with the Url supplied
+        WebHostUrl = "http://mono.servicestack.net/docs",   //Replace prefix with the Url supplied
         MarkdownBaseType = typeof(CustomMarkdownPage), //Set base class for all Markdown pages
         MarkdownGlobalHelpers = new Dictionary<string, Type> { 
             {"Ext", typeof(CustomStaticHelpers)}       //Define global Helpers e.g. at Ext.

--- a/src/Docs/ormlite/ormlite-overview.md
+++ b/src/Docs/ormlite/ormlite-overview.md
@@ -14,7 +14,7 @@ OrmLite was designed with a focus on the core objectives:
   * Create/Drop DB Table schemas using nothing but POCO class definitions (IOTW a true code-first ORM)
   * Simplicity - typed, wrist friendly API for common data access patterns.
   * High performance - with support for indexes, text blobs, etc.
-    * Amongst the [fastest Micro ORMs](http://servicestack.net/benchmarks/) for .NET (just behind [Dapper](http://code.google.com/p/dapper-dot-net/)).
+    * Amongst the [fastest Micro ORMs](http://mono.servicestack.net/benchmarks/) for .NET (just behind [Dapper](http://code.google.com/p/dapper-dot-net/)).
   * Expressive power and flexibility - with access to IDbCommand and raw SQL
   * Cross platform - supports multiple dbs (currently: Sqlite and Sql Server) running on both .NET and Mono platforms.
 

--- a/src/Docs/redis-admin-ui/redis-admin-ui-overview.md
+++ b/src/Docs/redis-admin-ui/redis-admin-ui-overview.md
@@ -7,7 +7,7 @@ Included is a ServiceStack web service layer which provide JSON, XML, JSV and SO
 Just like the RedisAdminUI this allows you to fully manage your redis-server instance using javascript from a browser.
 
 ##Live Demo
-A live demo of the RedisAdminUI can be found here [http://servicestack.net/RedisAdminUI/AjaxClient/](http://servicestack.net/RedisAdminUI/AjaxClient/)
+A live demo of the RedisAdminUI can be found here [http://mono.servicestack.net/RedisAdminUI/AjaxClient/](http://mono.servicestack.net/RedisAdminUI/AjaxClient/)
 
 View the demos live list of the [available web services](http://www.servicestack.net/RedisAdminUI/servicestack/metadata).
 

--- a/src/Docs/redis-client/redis-client.md
+++ b/src/Docs/redis-client/redis-client.md
@@ -33,7 +33,7 @@ Each client is optimized for maximum efficiency and provides layered functionali
 At all times you can pick the most optimal Redis Client for your needs so you can achieve maximum efficiency in your applications.
 
 ### Redis Client API Overview
-[![Redis Client API](http://servicestack.net/img/Redis-annotated-preview.png)](http://servicestack.net/img/Redis-annotated.png)
+[![Redis Client API](http://mono.servicestack.net/img/Redis-annotated-preview.png)](http://mono.servicestack.net/img/Redis-annotated.png)
 
 ### Thread-safe client managers
 For multi-threaded applications you can choose from our different client connection managers:

--- a/src/Docs/text-serializers/json-csv-jsv-serializers.md
+++ b/src/Docs/text-serializers/json-csv-jsv-serializers.md
@@ -15,7 +15,7 @@ Benchmarks for .NET's popular Binary and JSON Serializers are available at: [ser
 
 ## NuGet ServiceStack.Text
 
-![Install-Package ServiceStack.Text](http://servicestack.net/img/nuget-servicestack.text.png)
+![Install-Package ServiceStack.Text](http://mono.servicestack.net/img/nuget-servicestack.text.png)
 
 ## ServiceStack.JsonSerializer - the fastest JSON Serializer for .NET
 For reasons outlined [in this blog post](http://www.servicestack.net/mythz_blog/?p=344) I decided to re-use *TypeSerializer's* text processing-core to create ServiceStack.JsonSerializer - the fastest JSON Serializer for .NET.

--- a/src/MonoTouch/RestFilesClient/RestFilesClient/Main.cs
+++ b/src/MonoTouch/RestFilesClient/RestFilesClient/Main.cs
@@ -24,8 +24,8 @@ namespace RestFilesClient
 	// The name AppDelegate is referenced in the MainWindow.xib file.
 	public partial class AppDelegate : UIApplicationDelegate
 	{
-		JsonServiceClient gateway = new JsonServiceClient("http://servicestack.net/RestFiles");
-		//JsvServiceClient gateway = new JsvServiceClient("http://servicestack.net/RestFiles");
+		JsonServiceClient gateway = new JsonServiceClient("http://mono.servicestack.net/RestFiles");
+		//JsvServiceClient gateway = new JsvServiceClient("http://mono.servicestack.net/RestFiles");
 		
 		// This method is invoked when the application has loaded its UI and its ready to run
 		public override bool FinishedLaunching (UIApplication app, NSDictionary options)

--- a/src/RedisStackOverflow/RedisStackOverflow/default.htm
+++ b/src/RedisStackOverflow/RedisStackOverflow/default.htm
@@ -376,7 +376,7 @@
 </head>
 <body>
 
-    <a href="http://www.servicestack.net" style="display:block;position:absolute;top:5px;left:10px;"><img src="http://servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
+    <a href="http://www.servicestack.net" style="display:block;position:absolute;top:5px;left:10px;"><img src="http://mono.servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
 
     <div id="header-links">
         <a href="../ServiceStack.Hello/">Hello World</a>

--- a/src/RestFiles/RestFiles/README.md
+++ b/src/RestFiles/RestFiles/README.md
@@ -16,13 +16,13 @@ Because of the advanced HTML5 features used its best viewed in a modern browser 
 The /files service exposes a complete strong-typed REST-ful API, the entire implementation of which fits in only   
 [1 C# class](https://github.com/ServiceStack/ServiceStack.Examples/blob/master/src/RestFiles/RestFiles.ServiceInterface/FilesService.cs).
 
-As it was developed using the http://servicestack.net Open Source .NET/Mono Web Services Framework
+As it was developed using the http://mono.servicestack.net Open Source .NET/Mono Web Services Framework
 it also able to expose this REST-ful API over a myraid of formats (with no extra code/config):
 
-  * [json](http://servicestack.net/RestFiles/files/dtos/Types?format=json)
-  * [xml](http://servicestack.net/RestFiles/files/dtos/Types?format=xml)
-  * [jsv](http://servicestack.net/RestFiles/files/dtos/Types?format=jsv&debug=true)
-  * [csv](http://servicestack.net/RestFiles/files/dtos/Types?format=csv)
+  * [json](http://mono.servicestack.net/RestFiles/files/dtos/Types?format=json)
+  * [xml](http://mono.servicestack.net/RestFiles/files/dtos/Types?format=xml)
+  * [jsv](http://mono.servicestack.net/RestFiles/files/dtos/Types?format=jsv&debug=true)
+  * [csv](http://mono.servicestack.net/RestFiles/files/dtos/Types?format=csv)
 
 *Note: The speed of web services are faster than what they appear, as the delay + animations are for
  gratuitous purposes only :) All but the xml format uses the high-performance cross-platform,
@@ -32,15 +32,15 @@ it also able to expose this REST-ful API over a myraid of formats (with no extra
 
 SOAP 1.1/1.2 endpoints are also available at the following url:
 
-  * [soap11](http://servicestack.net/RestFiles/servicestack/soap11)
-  * [soap12](http://servicestack.net/RestFiles/servicestack/soap12)
+  * [soap11](http://mono.servicestack.net/RestFiles/servicestack/soap11)
+  * [soap12](http://mono.servicestack.net/RestFiles/servicestack/soap12)
 
 As a result of the strong-typed DTO pattern used to define the the webservice, ServiceStack is able to
 generate the xsds, wsdls, metadata documentation on the fly at:
 
-  * [docs](http://servicestack.net/RestFiles/servicestack/metadata)
-  * [xsd](http://servicestack.net/RestFiles/servicestack/metadata?xsd=1)
-  * [wsdl](http://servicestack.net/RestFiles/servicestack/soap12) (HTTP GET)
+  * [docs](http://mono.servicestack.net/RestFiles/servicestack/metadata)
+  * [xsd](http://mono.servicestack.net/RestFiles/servicestack/metadata?xsd=1)
+  * [wsdl](http://mono.servicestack.net/RestFiles/servicestack/soap12) (HTTP GET)
 
 Caveat: XmlSchema is not fully implemented as of MONO <= 2.8, so in many cases you will need to
 host your service on a Windows/.NET server to view your web services XSD and WSDLS.

--- a/src/RestFiles/RestFiles/default.htm
+++ b/src/RestFiles/RestFiles/default.htm
@@ -10,7 +10,7 @@
 <body>
     <a href="http://www.servicestack.net" style="display: block; position: absolute;
         top: 5px; left: 10px;">
-        <img src="http://servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
+        <img src="http://mono.servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
     <div id="header">
         <div id="header-links">
             <a href="../ServiceStack.Hello/">Hello World</a> <a href="../Backbone.Todos/">Todos</a>

--- a/src/ServiceStack.Examples/ServiceStack.Examples.Clients/js/ServiceStack.js
+++ b/src/ServiceStack.Examples/ServiceStack.Examples.Clients/js/ServiceStack.js
@@ -1,5 +1,5 @@
 /**
- * JSON Service Client Gateway for http://ServiceStack.net Web Services.
+ * JSON Service Client Gateway for http://mono.servicestack.net Web Services.
  * @requires jQuery.ajax or goog closure libarary XhrIo
  * @param {string} the baseUri of ServiceStack web services.
  * @constructor

--- a/src/ServiceStack.Hello/default.htm
+++ b/src/ServiceStack.Hello/default.htm
@@ -7,7 +7,7 @@
 <body>
     <a href="http://www.servicestack.net" style="display: block; position: absolute;
         top: 5px; left: 10px;">
-        <img src="http://servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
+        <img src="http://mono.servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
     <div id="header-links">
         <a href="../ServiceStack.Hello/">Hello World</a> <a href="../Backbone.Todos/">Todos</a>
         <a href="../RedisStackOverflow/">Redis StackOverflow</a> <a href="../RestFiles/">REST

--- a/src/ServiceStack.MovieRest/Web/default.htm
+++ b/src/ServiceStack.MovieRest/Web/default.htm
@@ -153,7 +153,7 @@
 </head>
 <body>
 	<a href="http://www.servicestack.net" style="display: block; position: absolute; top: 5px; left: 10px;">
-		<img src="http://servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
+		<img src="http://mono.servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
 	<div id="header-links">
 		<a href="../ServiceStack.Hello/">Hello World</a> <a href="../Backbone.Todos/">Todos</a>
 		<a href="../RedisStackOverflow/">Redis StackOverflow</a> 

--- a/src/ServiceStack.Northwind/ServiceStack.Northwind/default.htm
+++ b/src/ServiceStack.Northwind/ServiceStack.Northwind/default.htm
@@ -130,7 +130,7 @@
 </head>
 <body>
 
-	<a href="http://www.servicestack.net" style="display:block;position:absolute;top:5px;left:10px;"><img src="http://servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
+	<a href="http://www.servicestack.net" style="display:block;position:absolute;top:5px;left:10px;"><img src="http://mono.servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
 
     <div id="header-links">
         <a href="../ServiceStack.Hello/">Hello World</a>

--- a/src/ServiceStack.Northwind/ServiceStack.Northwind/vcard-format.htm
+++ b/src/ServiceStack.Northwind/ServiceStack.Northwind/vcard-format.htm
@@ -144,7 +144,7 @@
 </head>
 <body>
 
-	<a href="http://www.servicestack.net" style="display:block;position:absolute;top:5px;left:10px;"><img src="http://servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
+	<a href="http://www.servicestack.net" style="display:block;position:absolute;top:5px;left:10px;"><img src="http://mono.servicestack.net/icon-home.jpg" alt="ServiceStack Home" /></a>
 
     <div id="header-links">
         <a href="../ServiceStack.Hello/">Hello World</a>

--- a/src/StarterTemplates/ApiPath35/default.htm
+++ b/src/StarterTemplates/ApiPath35/default.htm
@@ -632,7 +632,7 @@ html {
       <br />
       Powered By Open Source
       <br />
-      <a href="http://servicestack.net">servicestack.net</a>
+      <a href="http://mono.servicestack.net">servicestack.net</a>
       | <a href="http://redis.io">redis</a>
       | <a href="http://www.mono-project.com">mono</a>
     </div>

--- a/src/StarterTemplates/ConsoleAppHost/default.htm
+++ b/src/StarterTemplates/ConsoleAppHost/default.htm
@@ -632,7 +632,7 @@ html {
       <br />
       Powered By Open Source
       <br />
-      <a href="http://servicestack.net">servicestack.net</a>
+      <a href="http://mono.servicestack.net">servicestack.net</a>
       | <a href="http://redis.io">redis</a>
       | <a href="http://www.mono-project.com">mono</a>
     </div>

--- a/src/StarterTemplates/CustomPath35/default.htm
+++ b/src/StarterTemplates/CustomPath35/default.htm
@@ -632,7 +632,7 @@ html {
       <br />
       Powered By Open Source
       <br />
-      <a href="http://servicestack.net">servicestack.net</a>
+      <a href="http://mono.servicestack.net">servicestack.net</a>
       | <a href="http://redis.io">redis</a>
       | <a href="http://www.mono-project.com">mono</a>
     </div>

--- a/src/StarterTemplates/CustomPath40/default.htm
+++ b/src/StarterTemplates/CustomPath40/default.htm
@@ -632,7 +632,7 @@ html {
       <br />
       Powered By Open Source
       <br />
-      <a href="http://servicestack.net">servicestack.net</a>
+      <a href="http://mono.servicestack.net">servicestack.net</a>
       | <a href="http://redis.io">redis</a>
       | <a href="http://www.mono-project.com">mono</a>
     </div>

--- a/src/StarterTemplates/RootPath35/default.htm
+++ b/src/StarterTemplates/RootPath35/default.htm
@@ -632,7 +632,7 @@ html {
       <br />
       Powered By Open Source
       <br />
-      <a href="http://servicestack.net">servicestack.net</a>
+      <a href="http://mono.servicestack.net">servicestack.net</a>
       | <a href="http://redis.io">redis</a>
       | <a href="http://www.mono-project.com">mono</a>
     </div>

--- a/src/StarterTemplates/RootPath40/default.htm
+++ b/src/StarterTemplates/RootPath40/default.htm
@@ -632,7 +632,7 @@ html {
       <br />
       Powered By Open Source
       <br />
-      <a href="http://servicestack.net">servicestack.net</a>
+      <a href="http://mono.servicestack.net">servicestack.net</a>
       | <a href="http://redis.io">redis</a>
       | <a href="http://www.mono-project.com">mono</a>
     </div>

--- a/src/StarterTemplates/WinServiceAppHost/default.htm
+++ b/src/StarterTemplates/WinServiceAppHost/default.htm
@@ -632,7 +632,7 @@ html {
       <br />
       Powered By Open Source
       <br />
-      <a href="http://servicestack.net">servicestack.net</a>
+      <a href="http://mono.servicestack.net">servicestack.net</a>
       | <a href="http://redis.io">redis</a>
       | <a href="http://www.mono-project.com">mono</a>
     </div>


### PR DESCRIPTION
I would really liked if [servicestack.net](http://servicestack.net) used `url rewrite` to redirect to [mono.servicestack.net](http://mono.servicestack.net) when referenced by [github](http://stackoverflow.com) or [stackoverflow](http://github.com)

``` xml
<rules>
  <rule name="RedirectToMono" stopProcessing="true">
    <match url="(linksremovedpattern)" />
    <conditions>
      <add input="{HTTP_REFERER}" pattern="http://stackoverflow.com/(.*)" negate="true" />
    </conditions>
    <action type="Redirect" url="http://mono.servicestack.net/{R:1}" />
  </rule>
</rules>
```
